### PR TITLE
Add slim psr7 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a very basic example of a [Slim Framework](https://www.
    ```bash
    composer install
    ```
+> Slim 4 requires a PSR-17/PSR-7 implementation such as `slim/psr7`.
 2. Start the PHP built-in web server:
    ```bash
    php -S localhost:8080 -t public

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
-    "require": {
-        "slim/slim": "^4.10"
-    },
-    "autoload": {
-        "psr-4": {
-            "": "src/"
-        }
+  "require": {
+    "slim/slim": "^4.10",
+    "slim/psr7": "^1.6"
+  },
+  "autoload": {
+    "psr-4": {
+      "": "src/"
     }
+  }
 }


### PR DESCRIPTION
## Summary
- update `composer.json` with a PSR-7 implementation
- add a note in the README about needing a PSR-17/PSR-7 implementation

## Testing
- `composer update` *(fails: command not found)*